### PR TITLE
updated scarf community slack invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 
 <p>
-  <a href="https://join.slack.com/t/scarf-community/shared_invite/zt-ptndha07-Vs88XHYyHnnAOIEw9AZMgg">
+  <a href="https://tinyurl.com/scarf-community-slack">
     <img src="https://img.shields.io/badge/Scarf%20Community%20-Slack-blue" alt="Join the Scarf Community Slack" />
   </a>
 </p>
@@ -44,4 +44,4 @@ A collection of resources relating to Scarf and our story, including origins, in
 
 ### Community 
 
-Join the [Scarf-Community workspace](https://join.slack.com/t/scarf-community/shared_invite/zt-ptndha07-Vs88XHYyHnnAOIEw9AZMgg) on Slack to learn more about our products and plans. We'll keep an eye out for your questions and concerns. And if you have issues that aren't covered in Scarf Docs, we'd love to hear from you. 
+Join the [Scarf-Community workspace](https://tinyurl.com/scarf-community-slack) on Slack to learn more about our products and plans. We'll keep an eye out for your questions and concerns. And if you have issues that aren't covered in Scarf Docs, we'd love to hear from you. 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,4 +6,4 @@ This site documents the various components of Scarf's toolchain for maintainers.
 
 You can contribute to the docs directly, they are hosted on [GitHub](https://github.com/scarf-sh/docs).
 
-Want to meet the people the people of Scarf—staff, open source maintainers, end-users and learn more about our products and plans? Join the [Scarf-Community workspace on Slack](https://join.slack.com/t/scarf-community/shared_invite/zt-ptndha07-Vs88XHYyHnnAOIEw9AZMgg). We'll keep an eye out for your questions and concerns.
+Want to meet the people the people of Scarf—staff, open source maintainers, end-users and learn more about our products and plans? Join the [Scarf-Community workspace on Slack](https://tinyurl.com/join-scarf-community). We'll keep an eye out for your questions and concerns.


### PR DESCRIPTION
expires on July 7. using custom tinyurl.