### PR TITLE
Markdown image alignment

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -24,9 +24,11 @@ Using Scarf, users can pull your Docker container images via Scarf Gateway using
 2.  Click `New Package` in the navigation.
 
 3.  Select the Create a Package drop-down and click on the package type you would like to create. For this section you will click `Docker`
+
     ![Create a package](assets/pics/quick-start/create_package.png)
 4.  Enter the current pull command for your Docker container.
     The Docker command for the `hello-world` package is `docker pull hello-world`.
+
     ![Enter the docker pull command](assets/pics/quick-start/pull_command.png)
 5.  Optional: You can add a custom domain or use the domain provided by Scarf Gateway.
 
@@ -49,9 +51,11 @@ Tracking pixels are used to leverage the web traffic from your project’s docum
 
 2. Under Documentation Insights enter a name for the pixel. For this example enter the name `readme`.
 3. Select the newly created `hello-world` package.
+
    ![Select the hello-world package](assets/pics/quick-start/readMe_pixel.png)
 4. Click `Create a New Pixel`
 5. Copy the newly created pixel <img> tag and add it to your website, documentation, or any other web properties associated with your project.
+
    ![copy the newly crete pixel tag](assets/pics/quick-start/copied_pixel.png)
 
 For more information on Tracking Pixels see the Documentation Insights section of our docs.


### PR DESCRIPTION
Hi,
when reading through documentation, I found a case of misaligned images that happens for some widths (tested both in Safari and Chrome):
![image](https://user-images.githubusercontent.com/22241847/165276751-fcce3eba-8c2a-4ca9-a2d6-815c1c8d0e4e.png)

It can be aligned either by adding an empty line before an image, or adding explicit line break (`<br>` or backslash). I chose the former, but it's a matter of taste.

After this change, the images align neatly:
![image](https://user-images.githubusercontent.com/22241847/165277378-a9307f9c-d07c-460d-b6b4-08e325a8753f.png)
