### PR TITLE
Enable dark mode switcher

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,27 @@ theme:
   name: material
   logo: assets/scarf_text.svg
   custom_dir: overrides
+  palette:
+
+    # Palette toggle for automatic mode
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+
+    # Palette toggle for light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference
 site_description: |
   Scarf's Technical Documentation & API Reference
 extra_css:


### PR DESCRIPTION
I just saw material mkdocs now offers a dark mode switcher, this PR turns it on. 