### PR TITLE
fix: correct link to the v2 api documentation in gateway docs

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -230,7 +230,7 @@ Downloads will typically show up in your dashboard in 30 minutes and up to 2-3 h
 
 **Is there an API I can use to pull my stats, manage my packages, etc?**
 
-Yes! See [our API documentation](/api) for more information.
+Yes! See [our API documentation](https://api-docs.scarf.sh/v2.html) for more information.
 
 **I have more questions, where is the best place to ask?**
 


### PR DESCRIPTION
At present, the link to the API documentation in the Gateway docs points to a dead link - https://docs.scarf.sh/api. This updates the link to point to the v2 api documentation at https://api-docs.scarf.sh/v2.html